### PR TITLE
fix: resolve clippy warnings in codecs and dice

### DIFF
--- a/src/codecs/gnuid.rs
+++ b/src/codecs/gnuid.rs
@@ -95,9 +95,9 @@ pub fn decode_key<const N: u8>(key: [u8; 10]) -> Position<N> {
     }
     bit_index += 1;
 
-    for point in O_BAR + 1..X_BAR {
+    for pip in pips.iter_mut().take(X_BAR).skip(O_BAR + 1) {
         while (key[bit_index / 8] >> (bit_index % 8)) & 1 == 1 {
-            pips[point] += 1;
+            *pip += 1;
             x_pieces += 1;
             bit_index += 1;
         }

--- a/src/codecs/move_text.rs
+++ b/src/codecs/move_text.rs
@@ -45,7 +45,7 @@ pub fn normalize(text: &str) -> Option<String> {
     }
     let mut steps: Vec<String> = Vec::new();
     for token in text.split_whitespace() {
-        let cleaned = token.replace('*', "").replace(',', "");
+        let cleaned = token.replace(['*', ','], "");
         let parts: Vec<&str> = cleaned.split('/').collect();
         let points = parse_path_points(&parts)?;
         for pair in points.windows(2) {
@@ -223,7 +223,7 @@ fn collect_paths<const N: u8>(
     for from in 1..=25 {
         if let Some(next) = current.try_move_single_checker(from, die) {
             found_any = true;
-            let to = if from > die { from - die } else { 0 };
+            let to = from.saturating_sub(die);
             steps.push(Step { from, to });
             collect_paths(
                 next,

--- a/src/codecs/xgid.rs
+++ b/src/codecs/xgid.rs
@@ -184,10 +184,10 @@ pub fn encode_board_for_position<const N: u8>(position: Position<N>) -> String {
         chars[25] = b'A' + (o_bar - 1);
     }
 
-    for i in 1..=24usize {
+    for (i, ch) in chars.iter_mut().enumerate().take(25).skip(1) {
         let pip = 25 - i;
         let n = position.pip(pip);
-        chars[i] = if n > 0 {
+        *ch = if n > 0 {
             b'a' + (n as u8 - 1)
         } else if n < 0 {
             b'A' + ((-n) as u8 - 1)

--- a/src/dice.rs
+++ b/src/dice.rs
@@ -26,7 +26,7 @@ pub struct MixedDice {
 /// As `usize` is also returned how often those dice on average appear in 1296 rolls.
 /// Two double rolls appear 1 time, two mixed rolls appear 4 times.
 /// A combination of a double and a mixed roll appears 2 times.
-pub const ALL_441: [([Dice; 2], usize); 441] = Dice::all_441();
+pub static ALL_441: [([Dice; 2], usize); 441] = Dice::all_441();
 
 /// Contains all 21 possibilities of dice and a number of how often they appear in 36 rolls.
 ///


### PR DESCRIPTION
## Summary
- resolve clippy warnings in `gnuid`, `move_text`, and `xgid` by adopting iterator-based and saturating operations
- convert `ALL_441` from `const` to `static` to satisfy large array lint
- verify clean lint/test state with `cargo clippy --all-targets --all-features` and `cargo test`